### PR TITLE
Add username back to the user resource

### DIFF
--- a/docs/resources/api_token.md
+++ b/docs/resources/api_token.md
@@ -16,7 +16,7 @@ Provides a resource for managing unleash api tokens.
 resource "unleash_api_token" "my_token" {
   username    = "bobjoe"
   type        = "client"
-  expires_at  = "2024-10-19"
+  expires_at  = "2050-04-15T14:30:45Z"
   environment = "development"
   projects    = ["*"]
 }
@@ -34,7 +34,7 @@ resource "unleash_api_token" "my_token" {
 
 - `created_at` (String) The API token creation date.
 - `environment` (String) The environment the token will have access to. By default, it has access to the `development` environment.
-- `expires_at` (String) The API token expiration date.
+- `expires_at` (String) The API token expiration date in RFC3339 format. If not set, the token will not expire.
 - `projects` (Set of String) The project(s) the token will have access to. Use `["*"]` for all projects. By default, it will have access to all projects.
 - `secret` (String, Sensitive) The API token secret.
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -29,6 +29,7 @@ resource "unleash_user" "my_user" {
 - `email` (String) The user's email address.
 - `name` (String) The user's name.
 - `root_role` (String) The role to assign to the user. Can be `Admin`, `Editor` or `Viewer`
+- `username` (String) The user's username. Changing it forces a new resource to be created.
 
 ### Optional
 

--- a/examples/resources/unleash_api_token/resource.tf
+++ b/examples/resources/unleash_api_token/resource.tf
@@ -1,7 +1,7 @@
 resource "unleash_api_token" "my_token" {
   username    = "bobjoe"
   type        = "client"
-  expires_at  = "2024-10-19"
+  expires_at  = "2050-04-15T14:30:45Z"
   environment = "development"
   projects    = ["*"]
 }

--- a/internal/provider/resource_api_token.go
+++ b/internal/provider/resource_api_token.go
@@ -53,7 +53,7 @@ func resourceApiToken() *schema.Resource {
 				ForceNew:    true,
 			},
 			"expires_at": {
-				Description: "The API token expiration date.",
+				Description: "The API token expiration date in RFC3339 format. If not set, the token will not expire.",
 				Type:        schema.TypeString,
 				Optional:    true,
 			},

--- a/internal/provider/resource_user_test.go
+++ b/internal/provider/resource_user_test.go
@@ -22,6 +22,7 @@ func TestAccResourceUser(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("unleash_user.foo", "name", regexp.MustCompile("^bar")),
 					resource.TestMatchResourceAttr("unleash_user.foo", "email", regexp.MustCompile("^foo.+@foo.com.br$")),
+					resource.TestMatchResourceAttr("unleash_user.foo", "username", regexp.MustCompile("^xyz")),
 					resource.TestMatchResourceAttr("unleash_user.foo", "root_role", regexp.MustCompile("^Admin$")),
 				),
 			},
@@ -31,9 +32,10 @@ func TestAccResourceUser(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify updates took effect
 					resource.TestMatchResourceAttr("unleash_user.foo", "root_role", regexp.MustCompile("^Viewer$")),
+					resource.TestMatchResourceAttr("unleash_user.foo", "name", regexp.MustCompile("^Joana")),
+					resource.TestMatchResourceAttr("unleash_user.foo", "email", regexp.MustCompile("^foo.+@foozzz.com.br$")),
 					// Verify unchanged attributes
-					resource.TestMatchResourceAttr("unleash_user.foo", "name", regexp.MustCompile("^bar")),
-					resource.TestMatchResourceAttr("unleash_user.foo", "email", regexp.MustCompile("^foo.+@foo.com.br$")),
+					resource.TestMatchResourceAttr("unleash_user.foo", "username", regexp.MustCompile("^xyz")),
 				),
 			},
 		},
@@ -44,16 +46,18 @@ func testAccResourceUserInitial(suffix string) string {
 	return fmt.Sprintf(`
 resource "unleash_user" "foo" {
   name = "bar"
+	username = "xyz%s"
   email = "foo%s@foo.com.br"
   root_role = "Admin"
-}`, suffix)
+}`, suffix, suffix)
 }
 
 func testAccResourceUserUpdated(suffix string) string {
 	return fmt.Sprintf(`
 resource "unleash_user" "foo" {
-  name = "bar"
-  email = "foo%s@foo.com.br"
+  name = "Joana Darc"
+	username = "xyz%s"
+  email = "foo%s@foozzz.com.br"
   root_role = "Viewer"
-}`, suffix)
+}`, suffix, suffix)
 }


### PR DESCRIPTION
- [x] Add `username` back to the user resource.
- [x] Update docs.
- [x] Update API token `expires_at` example and update description.