### PR TITLE
Use official API client for api token and user data sources

### DIFF
--- a/docs/data-sources/api_token.md
+++ b/docs/data-sources/api_token.md
@@ -14,8 +14,8 @@ Retrieves a single api token based on provided filters. It raises an error if mo
 
 ```terraform
 data "unleash_api_token" "filter" {
-  username = "bobjoe"
-  projects = ["*"]
+  token_name = "bobjoe"
+  projects   = ["*"]
 }
 
 output "token" {
@@ -28,7 +28,7 @@ output "token" {
 
 ### Required
 
-- `username` (String) Filter token by username.
+- `token_name` (String) Filter token by the unique name of the token. This property replaced `username` in Unleash v5).
 
 ### Optional
 
@@ -49,5 +49,5 @@ Read-Only:
 - `expires_at` (String)
 - `projects` (Set of String)
 - `secret` (String)
+- `token_name` (String)
 - `type` (String)
-- `username` (String)

--- a/docs/data-sources/api_tokens.md
+++ b/docs/data-sources/api_tokens.md
@@ -14,7 +14,7 @@ Retrieves existing api tokens. Filters are optional.
 
 ```terraform
 data "unleash_api_tokens" "bobjoe_tokens" {
-  username = "bobjoe"
+  token_name = "bobjoe"
 }
 
 output "tokens" {
@@ -28,7 +28,7 @@ output "tokens" {
 ### Optional
 
 - `projects` (Set of String) Filter tokens by project(s).
-- `username` (String) Filter tokens by username.
+- `token_name` (String) Filter token by the unique name of the token. This property replaced `username` in Unleash v5).
 
 ### Read-Only
 
@@ -45,5 +45,5 @@ Read-Only:
 - `expires_at` (String)
 - `projects` (Set of String)
 - `secret` (String)
+- `token_name` (String)
 - `type` (String)
-- `username` (String)

--- a/docs/resources/api_token.md
+++ b/docs/resources/api_token.md
@@ -14,7 +14,7 @@ Provides a resource for managing unleash api tokens.
 
 ```terraform
 resource "unleash_api_token" "my_token" {
-  username    = "bobjoe"
+  token_name  = "bobjoe"
   type        = "client"
   expires_at  = "2050-04-15T14:30:45Z"
   environment = "development"
@@ -27,8 +27,8 @@ resource "unleash_api_token" "my_token" {
 
 ### Required
 
+- `token_name` (String) The unique name of the token. This property replaced `username` in Unleash v5).
 - `type` (String) The type of the API token. Can be `client`, `admin` or `frontend`
-- `username` (String) The unique name of the token. Used as `tokenName` in the API (username is deprecated).
 
 ### Optional
 

--- a/examples/data-sources/unleash_api_token/data-source.tf
+++ b/examples/data-sources/unleash_api_token/data-source.tf
@@ -1,6 +1,6 @@
 data "unleash_api_token" "filter" {
-  username = "bobjoe"
-  projects = ["*"]
+  token_name = "bobjoe"
+  projects   = ["*"]
 }
 
 output "token" {

--- a/examples/data-sources/unleash_api_tokens/data-source.tf
+++ b/examples/data-sources/unleash_api_tokens/data-source.tf
@@ -1,5 +1,5 @@
 data "unleash_api_tokens" "bobjoe_tokens" {
-  username = "bobjoe"
+  token_name = "bobjoe"
 }
 
 output "tokens" {

--- a/examples/resources/unleash_api_token/resource.tf
+++ b/examples/resources/unleash_api_token/resource.tf
@@ -1,5 +1,5 @@
 resource "unleash_api_token" "my_token" {
-  username    = "bobjoe"
+  token_name  = "bobjoe"
   type        = "client"
   expires_at  = "2050-04-15T14:30:45Z"
   environment = "development"

--- a/internal/provider/data_source_user.go
+++ b/internal/provider/data_source_user.go
@@ -57,25 +57,25 @@ func dataSourceUser() *schema.Resource {
 }
 
 func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*ApiClients).PhilipsUnleashClient
+	client := meta.(*ApiClients).UnleashClient
 
 	var diags diag.Diagnostics
 
 	id := d.Get("id").(int)
-	stringId := strconv.Itoa(id)
-	userDetails, _, err := client.Users.GetUserById(stringId)
+	userDetails, _, err := client.UsersAPI.GetUser(ctx, int32(id)).Execute()
 
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
+	stringId := strconv.Itoa(id)
 	d.SetId(stringId)
 
 	_ = d.Set("name", userDetails.Name)
 	_ = d.Set("username", userDetails.Username)
 	_ = d.Set("email", userDetails.Email)
 	for k, v := range rolesLookup {
-		if v == userDetails.RootRole {
+		if int32(v) == *userDetails.RootRole {
 			_ = d.Set("root_role", k)
 		}
 	}

--- a/internal/provider/data_source_users.go
+++ b/internal/provider/data_source_users.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -88,11 +87,7 @@ func dataSourceUsersRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.SetId(query)
 
 	users := []interface{}{}
-	for _, user := range *matchedUsers {
-		userDetails, _, err := client.Users.GetUserById(strconv.Itoa(user.Id))
-		if err != nil {
-			return diag.FromErr(err)
-		}
+	for _, userDetails := range *matchedUsers {
 		tfMap := map[string]interface{}{}
 		tfMap["id"] = userDetails.Id
 		tfMap["name"] = userDetails.Name

--- a/internal/provider/resource_api_token.go
+++ b/internal/provider/resource_api_token.go
@@ -25,8 +25,8 @@ func resourceApiToken() *schema.Resource {
 
 		// The descriptions are used by the documentation generator and the language server.
 		Schema: map[string]*schema.Schema{
-			"username": {
-				Description: "The unique name of the token. Used as `tokenName` in the API (username is deprecated).",
+			"token_name": {
+				Description: "The unique name of the token. This property replaced `username` in Unleash v5).",
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
@@ -79,7 +79,7 @@ func resourceApiTokenCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 	var diags diag.Diagnostics
 
-	tokenName := d.Get("username").(string)
+	tokenName := d.Get("token_name").(string)
 	tokenType := d.Get("type").(string)
 	environment := d.Get("environment").(string)
 	projects := toStringArr(d.Get("projects").(*schema.Set).List())
@@ -136,7 +136,7 @@ func resourceApiTokenRead(ctx context.Context, d *schema.ResourceData, meta inte
 		}
 	}
 
-	_ = d.Set("username", foundApiToken.TokenName)
+	_ = d.Set("token_name", foundApiToken.TokenName)
 	_ = d.Set("type", foundApiToken.Type)
 	_ = d.Set("environment", foundApiToken.Environment)
 	_ = d.Set("created_at", foundApiToken.CreatedAt.Format(time.RFC3339))

--- a/internal/provider/resource_api_token_test.go
+++ b/internal/provider/resource_api_token_test.go
@@ -20,7 +20,7 @@ func TestAccResourceApiToken(t *testing.T) {
 				// Initial creation
 				Config: testAccResourceApiTokenInitial(randomSuffix),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestMatchResourceAttr("unleash_api_token.foo", "username", regexp.MustCompile("^bar")),
+					resource.TestMatchResourceAttr("unleash_api_token.foo", "token_name", regexp.MustCompile("^bar")),
 					resource.TestMatchResourceAttr("unleash_api_token.foo", "secret", regexp.MustCompile(`^\*:development\.`)),
 					resource.TestCheckResourceAttr("unleash_api_token.foo", "environment", "development"),
 					resource.TestCheckResourceAttr("unleash_api_token.foo", "projects.#", "1"),
@@ -33,7 +33,7 @@ func TestAccResourceApiToken(t *testing.T) {
 					// Verify updates took effect
 					resource.TestMatchResourceAttr("unleash_api_token.foo", "expires_at", regexp.MustCompile("^2023-04-15T14:30:45Z$")),
 					// Verify unchanged attributes
-					resource.TestMatchResourceAttr("unleash_api_token.foo", "username", regexp.MustCompile("^bar")),
+					resource.TestMatchResourceAttr("unleash_api_token.foo", "token_name", regexp.MustCompile("^bar")),
 					resource.TestMatchResourceAttr("unleash_api_token.foo", "secret", regexp.MustCompile(`^\*:development\.`)),
 					resource.TestCheckResourceAttr("unleash_api_token.foo", "environment", "development"),
 					resource.TestCheckResourceAttr("unleash_api_token.foo", "projects.#", "1"),
@@ -46,7 +46,7 @@ func TestAccResourceApiToken(t *testing.T) {
 func testAccResourceApiTokenInitial(suffix string) string {
 	return fmt.Sprintf(`
 resource "unleash_api_token" "foo" {
-  username    = "bar%s"
+  token_name    = "bar%s"
   type        = "client"
   environment = "development"
   projects    = ["*"]
@@ -56,7 +56,7 @@ resource "unleash_api_token" "foo" {
 func testAccResourceApiTokenUpdated(suffix string) string {
 	return fmt.Sprintf(`
 resource "unleash_api_token" "foo" {
-  username    = "bar%s"
+  token_name    = "bar%s"
   type        = "client"
   environment = "development"
   projects    = ["*"]


### PR DESCRIPTION
- [ ] Adapt API token and user data sources to use the official API client.
- [ ] Rename property `username` to `token_name` to make it clear that `username` is deprecated from Unleash v5 onward.