### PR TITLE
userIds strategy deprecated

### DIFF
--- a/internal/provider/resource_feature_enabling_test.go
+++ b/internal/provider/resource_feature_enabling_test.go
@@ -37,9 +37,9 @@ resource "unleash_strategy_assignment" "foo" {
 	feature_name  = unleash_feature.foo.name
 	project_id    = "default"
 	environment   = "development"
-	strategy_name = "userWithId"
+	strategy_name = "remoteAddress"
 	parameters = {
-	  userIds    = "xyz,bar"
+	  IPs    = "xyz,bar"
 	}
 }
 resource "unleash_feature_enabling" "foo" {

--- a/internal/provider/resource_strategy_assingment_test.go
+++ b/internal/provider/resource_strategy_assingment_test.go
@@ -24,8 +24,8 @@ func TestAccResourceStrategyAssignment(t *testing.T) {
 					resource.TestCheckResourceAttr("unleash_strategy_assignment.foo", "parameters.rollout", "68"),
 					resource.TestCheckResourceAttr("unleash_strategy_assignment.foo", "parameters.stickiness", "random"),
 					resource.TestCheckResourceAttr("unleash_strategy_assignment.foo", "parameters.groupId", "toggle"),
-					resource.TestCheckResourceAttr("unleash_strategy_assignment.foo2", "strategy_name", "userWithId"),
-					resource.TestCheckResourceAttr("unleash_strategy_assignment.foo2", "parameters.userIds", "xyz,bar"),
+					resource.TestCheckResourceAttr("unleash_strategy_assignment.foo2", "strategy_name", "remoteAddress"),
+					resource.TestCheckResourceAttr("unleash_strategy_assignment.foo2", "parameters.IPs", "xyz,bar"),
 				),
 			},
 		},
@@ -53,9 +53,9 @@ resource "unleash_strategy_assignment" "foo2" {
 	feature_name  = unleash_feature.foo.name
 	project_id    = "default"
 	environment   = "development"
-	strategy_name = "userWithId"
+	strategy_name = "remoteAddress"
 	parameters = {
-	  userIds    = "xyz,bar"
+	  IPs    = "xyz,bar"
 	}
 }
 `, utils.RandomString(4))


### PR DESCRIPTION
userIds strategy was removed from new installations of Unleash, so I am removing it from the tests since the tests always start a fresh Unleash server in the latest version.