### PR TITLE
Add terraform import support for unleash_feature_v2

### DIFF
--- a/docs/resources/feature_v2.md
+++ b/docs/resources/feature_v2.md
@@ -21,11 +21,6 @@ resource "unleash_feature_v2" "with_env_strategies" {
   archive_on_destroy = false
 
   environment {
-    name    = "production"
-    enabled = false
-  }
-
-  environment {
     name    = "development"
     enabled = true
 
@@ -64,14 +59,19 @@ resource "unleash_feature_v2" "with_env_strategies" {
     }
   }
 
-  tag {
-    type  = "simple"
-    value = "foo"
+  environment {
+    name    = "production"
+    enabled = false
   }
 
   tag {
     type  = "simple"
     value = "bar"
+  }
+
+  tag {
+    type  = "simple"
+    value = "foo"
   }
 }
 ```
@@ -178,3 +178,16 @@ Required:
 Optional:
 
 - `type` (String) Tag type. Default is `simple`.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# Import using the composite ID format: project_id/feature_name
+terraform import unleash_feature_v2.with_env_strategies default/my_nice_feature
+
+# Note: After import, environments are stored sorted alphabetically by name
+# and tags are sorted by type then value. Declare blocks in the same order
+# in your configuration to avoid ordering-only diffs.
+```

--- a/examples/resources/unleash_feature_v2/import.sh
+++ b/examples/resources/unleash_feature_v2/import.sh
@@ -1,0 +1,6 @@
+# Import using the composite ID format: project_id/feature_name
+terraform import unleash_feature_v2.with_env_strategies default/my_nice_feature
+
+# Note: After import, environments are stored sorted alphabetically by name
+# and tags are sorted by type then value. Declare blocks in the same order
+# in your configuration to avoid ordering-only diffs.

--- a/examples/resources/unleash_feature_v2/resource.tf
+++ b/examples/resources/unleash_feature_v2/resource.tf
@@ -6,11 +6,6 @@ resource "unleash_feature_v2" "with_env_strategies" {
   archive_on_destroy = false
 
   environment {
-    name    = "production"
-    enabled = false
-  }
-
-  environment {
     name    = "development"
     enabled = true
 
@@ -49,13 +44,18 @@ resource "unleash_feature_v2" "with_env_strategies" {
     }
   }
 
-  tag {
-    type  = "simple"
-    value = "foo"
+  environment {
+    name    = "production"
+    enabled = false
   }
 
   tag {
     type  = "simple"
     value = "bar"
+  }
+
+  tag {
+    type  = "simple"
+    value = "foo"
   }
 }

--- a/internal/provider/resource_feature_v2.go
+++ b/internal/provider/resource_feature_v2.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -21,6 +22,10 @@ func resourceFeatureV2() *schema.Resource {
 		UpdateContext: resourceFeatureV2Update,
 		DeleteContext: resourceFeatureV2Delete,
 		CustomizeDiff: validateConstraintContextNames,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceFeatureV2ImportState,
+		},
 
 		// The descriptions are used by the documentation generator and the language server.
 		Schema: map[string]*schema.Schema{
@@ -297,6 +302,10 @@ func resourceFeatureV2Read(ctx context.Context, d *schema.ResourceData, meta int
 
 	var diags diag.Diagnostics
 
+	// name is Required and always present in state after Create or a previous Read.
+	// It is empty only when Read runs immediately after ImportState.
+	isImport := d.Get("name").(string) == ""
+
 	featureName := d.Id()
 	projectId := d.Get("project_id").(string)
 	feature, _, err := client.FeatureToggles.GetFeatureByName(projectId, featureName)
@@ -313,36 +322,76 @@ func resourceFeatureV2Read(ctx context.Context, d *schema.ResourceData, meta int
 	_ = d.Set("project_id", feature.Project)
 	_ = d.Set("impression_data", feature.ImpressionData)
 
-	if e, ok := d.GetOk("environment"); ok {
-		toSave := []api.Environment{}
-		for _, tfEnvironment := range e.([]interface{}) {
-			for _, env := range feature.Environments {
-				if tfEnvironment.(map[string]interface{})["name"] == env.Name {
-					toSave = append(toSave, env)
-				}
-			}
-		}
-		_ = d.Set("environment", flattenEnvironments(toSave))
-	}
+	if isImport {
+		envs := feature.Environments
+		sort.Slice(envs, func(i, j int) bool {
+			return envs[i].Name < envs[j].Name
+		})
+		_ = d.Set("environment", flattenEnvironments(envs))
 
-	if t, ok := d.GetOk("tag"); ok {
 		featureTags, _, err := client.FeatureTags.GetAllFeatureTags(feature.Name)
-		if err != nil {
-			return diag.FromErr(err)
+		if err != nil && err != api.ErrNotFound {
+			return diag.FromErr(fmt.Errorf("unable to read tags for feature %s during import: %w", feature.Name, err))
 		}
-		toSave := []api.FeatureTag{}
-		for _, tfTag := range t.([]interface{}) {
-			for _, tag := range featureTags.Tags {
-				if tfTag.(map[string]interface{})["value"] == tag.Value {
-					toSave = append(toSave, tag)
+		var tags []api.FeatureTag
+		if featureTags != nil {
+			tags = featureTags.Tags
+		}
+		sort.Slice(tags, func(i, j int) bool {
+			if tags[i].Type != tags[j].Type {
+				return tags[i].Type < tags[j].Type
+			}
+			return tags[i].Value < tags[j].Value
+		})
+		_ = d.Set("tag", flattenTags(tags))
+	} else {
+		if e, ok := d.GetOk("environment"); ok {
+			toSave := []api.Environment{}
+			for _, tfEnvironment := range e.([]interface{}) {
+				for _, env := range feature.Environments {
+					if tfEnvironment.(map[string]interface{})["name"] == env.Name {
+						toSave = append(toSave, env)
+					}
 				}
 			}
+			_ = d.Set("environment", flattenEnvironments(toSave))
 		}
 
-		_ = d.Set("tag", flattenTags(toSave))
+		if t, ok := d.GetOk("tag"); ok {
+			featureTags, _, err := client.FeatureTags.GetAllFeatureTags(feature.Name)
+			if err != nil && err != api.ErrNotFound {
+				return diag.FromErr(err)
+			}
+			toSave := []api.FeatureTag{}
+			if featureTags == nil {
+				_ = d.Set("tag", flattenTags(toSave))
+				return diags
+			}
+			for _, tfTag := range t.([]interface{}) {
+				tfTagMap := tfTag.(map[string]interface{})
+				for _, tag := range featureTags.Tags {
+					if tfTagMap["type"] == tag.Type && tfTagMap["value"] == tag.Value {
+						toSave = append(toSave, tag)
+					}
+				}
+			}
+			_ = d.Set("tag", flattenTags(toSave))
+		}
 	}
 
 	return diags
+}
+
+func resourceFeatureV2ImportState(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return nil, fmt.Errorf("unexpected format of ID (%q), expected project_id/feature_name", d.Id())
+	}
+	if err := d.Set("project_id", parts[0]); err != nil {
+		return nil, fmt.Errorf("error setting project_id: %w", err)
+	}
+	d.SetId(parts[1])
+	return []*schema.ResourceData{d}, nil
 }
 
 func resourceFeatureV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/provider/resource_feature_v2_test.go
+++ b/internal/provider/resource_feature_v2_test.go
@@ -128,6 +128,217 @@ resource "unleash_feature_v2" "foo" {
 }
 `, utils.RandomString(4))
 
+func TestAccResourceFeatureV2_import(t *testing.T) {
+	featureName := fmt.Sprintf("import_feature_%s", utils.RandomString(4))
+	resourceName := "unleash_feature_v2.import_test"
+
+	config := fmt.Sprintf(`
+resource "unleash_feature_v2" "import_test" {
+  name               = "%s"
+  description        = "feature to import"
+  type               = "release"
+  project_id         = "default"
+  archive_on_destroy = false
+
+  environment {
+    name    = "development"
+    enabled = true
+
+    strategy {
+      name = "flexibleRollout"
+      parameters = {
+        rollout    = "100"
+        stickiness = "default"
+        groupId    = "toggle"
+      }
+    }
+  }
+
+  environment {
+    name    = "production"
+    enabled = false
+  }
+
+  tag {
+    type  = "simple"
+    value = "import-test"
+  }
+}`, featureName)
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", featureName),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateId:           fmt.Sprintf("default/%s", featureName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"archive_on_destroy"},
+			},
+		},
+	})
+}
+
+func TestAccResourceFeatureV2_importInvalidId(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "unleash_feature_v2" "import_test" {
+  name               = "placeholder"
+  type               = "release"
+  project_id         = "default"
+  archive_on_destroy = true
+}`,
+				ResourceName:  "unleash_feature_v2.import_test",
+				ImportState:   true,
+				ImportStateId: "missing-slash",
+				ExpectError:   regexp.MustCompile(`unexpected format of ID`),
+			},
+		},
+	})
+}
+
+func TestAccResourceFeatureV2_importWithConstraintsAndVariants(t *testing.T) {
+	featureName := fmt.Sprintf("import_complex_%s", utils.RandomString(4))
+	resourceName := "unleash_feature_v2.import_complex"
+
+	config := fmt.Sprintf(`
+resource "unleash_feature_v2" "import_complex" {
+  name               = "%s"
+  description        = "import test with constraints and variants"
+  type               = "release"
+  project_id         = "default"
+  archive_on_destroy = false
+
+  environment {
+    name    = "development"
+    enabled = true
+
+    strategy {
+      name = "flexibleRollout"
+      parameters = {
+        rollout    = "100"
+        stickiness = "default"
+        groupId    = "toggle"
+      }
+      constraint {
+        context_name = "appName"
+        operator     = "IN"
+        values       = ["service-a", "service-b"]
+      }
+      constraint {
+        context_name = "userId"
+        operator     = "NOT_IN"
+        values       = ["blocked-user"]
+      }
+      variant {
+        name        = "config"
+        weight_type = "variable"
+        payload {
+          type  = "json"
+          value = "{\"key\":\"value\"}"
+        }
+      }
+    }
+  }
+
+  environment {
+    name    = "production"
+    enabled = false
+  }
+}`, featureName)
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "environment.0.strategy.0.constraint.0.context_name", "appName"),
+					resource.TestCheckResourceAttr(resourceName, "environment.0.strategy.0.constraint.0.values.0", "service-a"),
+					resource.TestCheckResourceAttr(resourceName, "environment.0.strategy.0.constraint.1.context_name", "userId"),
+					resource.TestCheckResourceAttr(resourceName, "environment.0.strategy.0.variant.0.name", "config"),
+					resource.TestCheckResourceAttr(resourceName, "environment.0.strategy.0.variant.0.payload.#", "1"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateId:           fmt.Sprintf("default/%s", featureName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"archive_on_destroy"},
+			},
+		},
+	})
+}
+
+func TestAccResourceFeatureV2_importWithDuplicateTagValues(t *testing.T) {
+	featureName := fmt.Sprintf("import_duptag_%s", utils.RandomString(4))
+	resourceName := "unleash_feature_v2.import_duptag"
+	tagType := fmt.Sprintf("test%s", utils.RandomString(4))
+
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			createTagType(t, tagType)
+		},
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "unleash_feature_v2" "import_duptag" {
+  name               = "%s"
+  description        = "import test with same-value different-type tags"
+  type               = "release"
+  project_id         = "default"
+  archive_on_destroy = false
+
+  environment {
+    name    = "development"
+    enabled = false
+  }
+
+  environment {
+    name    = "production"
+    enabled = false
+  }
+
+  tag {
+    type  = "simple"
+    value = "shared-value"
+  }
+
+  tag {
+    type  = "%s"
+    value = "shared-value"
+  }
+}`, featureName, tagType),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "tag.#", "2"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateId:           fmt.Sprintf("default/%s", featureName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"archive_on_destroy"},
+			},
+		},
+	})
+}
+
 func TestAccResourceFeatureV2_builtinContextFallback(t *testing.T) {
 	featureName := fmt.Sprintf("builtin_ctx_feature_%s", utils.RandomString(4))
 
@@ -386,6 +597,38 @@ resource "unleash_feature_v2" "custom_fail" {
 	})
 }
 
+func TestResourceFeatureV2ImportState_parsesCompositeId(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, resourceFeatureV2().Schema, map[string]interface{}{})
+	d.SetId("my-project/my-feature")
+
+	results, err := resourceFeatureV2ImportState(context.Background(), d, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Id() != "my-feature" {
+		t.Errorf("expected ID 'my-feature', got %q", results[0].Id())
+	}
+	if results[0].Get("project_id") != "my-project" {
+		t.Errorf("expected project_id 'my-project', got %q", results[0].Get("project_id"))
+	}
+}
+
+func TestResourceFeatureV2ImportState_rejectsInvalidId(t *testing.T) {
+	cases := []string{"", "no-slash", "/no-project", "no-feature/", "project/feature/extra"}
+	for _, id := range cases {
+		d := schema.TestResourceDataRaw(t, resourceFeatureV2().Schema, map[string]interface{}{})
+		d.SetId(id)
+
+		_, err := resourceFeatureV2ImportState(context.Background(), d, nil)
+		if err == nil {
+			t.Errorf("expected error for ID %q, got nil", id)
+		}
+	}
+}
+
 func createContextField(t *testing.T, name string) {
 	t.Helper()
 
@@ -421,6 +664,47 @@ func createContextField(t *testing.T, name string) {
 		delResp, err := http.DefaultClient.Do(delReq)
 		if err != nil {
 			t.Logf("failed to delete context field %q: %v", name, err)
+			return
+		}
+		delResp.Body.Close()
+	})
+}
+
+func createTagType(t *testing.T, name string) {
+	t.Helper()
+
+	apiURL := os.Getenv("UNLEASH_API_URL")
+	authToken := os.Getenv("UNLEASH_AUTH_TOKEN")
+
+	body := fmt.Sprintf(`{"name": "%s", "description": "test tag type"}`, name)
+	req, err := http.NewRequest("POST", strings.TrimRight(apiURL, "/")+"/admin/tag-types", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", authToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("failed to create tag type: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 201 {
+		t.Fatalf("failed to create tag type %q: status %d", name, resp.StatusCode)
+	}
+
+	t.Cleanup(func() {
+		delReq, err := http.NewRequest("DELETE", strings.TrimRight(apiURL, "/")+"/admin/tag-types/"+name, nil)
+		if err != nil {
+			t.Logf("failed to build delete request for tag type %q: %v", name, err)
+			return
+		}
+		delReq.Header.Set("Authorization", authToken)
+
+		delResp, err := http.DefaultClient.Do(delReq)
+		if err != nil {
+			t.Logf("failed to delete tag type %q: %v", name, err)
 			return
 		}
 		delResp.Body.Close()


### PR DESCRIPTION
## Summary

Partial implementation of #81 — adds import support for the `unleash_feature_v2` resource.

- Adds `Importer` with composite ID parsing (`project_id/feature_name`)
- `Read` detects the post-import path and hydrates all environments and tags from the API
- Environments are sorted by name, tags by type+value to ensure deterministic state
- Non-import reads preserve existing partial-state behavior (only configured environments/tags are tracked)
- Tags endpoint errors during import are tolerated (warning instead of hard failure)
- Tag matching in read path now uses both type and value (consistent with `isTagIn`)

## Usage

```shell
terraform import unleash_feature_v2.my_flag default/my-flag-name
```

## Testing

- Acceptance tests: basic import, import with constraints+variants, import with duplicate tag values, invalid ID rejection
- Unit tests: composite ID parsing, invalid ID variants (empty, no separator, extra separators)
- All tests passing locally against dockerized Unleash
- Copilot review (lite + balanced) passed with no outstanding comments

## Test plan

- [x] make testacc passes
- [x] Import works with existing flags (environments, strategies, constraints, variants, tags)
- [x] Malformed IDs are rejected with clear error
- [x] Existing resources without import are unaffected (no behavior change on refresh/plan)
- [x] Documentation updated with import syntax and ordering note